### PR TITLE
feat: add quick-login function

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -20,3 +20,4 @@ uos-02-fix-shell-nologin.patch
 uos-03-feat-can-switch-active-session.patch
 0002-feat-whitebox-scheme-adjustment.patch
 chore-adapt-to-qt6.patch
+uos-12-feat-dde-quick-login.patch

--- a/debian/patches/uos-12-feat-dde-quick-login.patch
+++ b/debian/patches/uos-12-feat-dde-quick-login.patch
@@ -1,0 +1,221 @@
+Index: lightdm/common/configuration.c
+===================================================================
+--- lightdm.orig/common/configuration.c
++++ lightdm/common/configuration.c
+@@ -391,6 +391,7 @@ config_init (Configuration *config)
+     g_hash_table_insert (config->priv->seat_keys, "autologin-session", GINT_TO_POINTER (KEY_SUPPORTED));
+     g_hash_table_insert (config->priv->seat_keys, "exit-on-failure", GINT_TO_POINTER (KEY_SUPPORTED));
+     g_hash_table_insert (config->priv->seat_keys, "xdg-seat", GINT_TO_POINTER (KEY_DEPRECATED));
++    g_hash_table_insert (config->priv->seat_keys, "quicklogin-enabled", GINT_TO_POINTER (KEY_SUPPORTED));
+ 
+     g_hash_table_insert (config->priv->xdmcp_keys, "enabled", GINT_TO_POINTER (KEY_SUPPORTED));
+     g_hash_table_insert (config->priv->xdmcp_keys, "port", GINT_TO_POINTER (KEY_SUPPORTED));
+Index: lightdm/src/greeter.c
+===================================================================
+--- lightdm.orig/src/greeter.c
++++ lightdm/src/greeter.c
+@@ -500,9 +500,11 @@ handle_authenticate (Greeter *greeter, g
+ 
+     /* Use non-interactive service for autologin user */
+     const gchar *autologin_username = g_hash_table_lookup (greeter->priv->hints, "autologin-user");
++    const gchar *quicklogin_enabled = g_hash_table_lookup (greeter->priv->hints, "quicklogin-enabled");
+     const gchar *service;
+     gboolean is_interactive;
+-    if (autologin_username != NULL && g_strcmp0 (username, autologin_username) == 0)
++    if ((autologin_username != NULL && g_strcmp0 (username, autologin_username) == 0)
++        || (quicklogin_enabled != NULL && g_strcmp0 (quicklogin_enabled, "true") == 0))
+     {
+         service = greeter->priv->autologin_pam_service;
+         is_interactive = FALSE;
+Index: lightdm/src/seat.c
+===================================================================
+--- lightdm.orig/src/seat.c
++++ lightdm/src/seat.c
+@@ -18,6 +18,7 @@
+ #include "guest-account.h"
+ #include "greeter-session.h"
+ #include "session-config.h"
++#include "common/user-list.h"
+ 
+ enum {
+     SESSION_ADDED,
+@@ -1149,6 +1150,11 @@ greeter_start_session_cb (Greeter *greet
+             if (!session_name && g_strcmp0 (user_get_name (user), autologin_username) == 0)
+                 session_name = seat_get_string_property (seat, "autologin-session");
+ 
++            /* Override session for quicklogin if configured */
++            const gchar *quicklogin_enabled = seat_get_string_property (seat, "quicklogin-enabled");
++            if (!session_name && g_strcmp0 (quicklogin_enabled, "true") == 0)
++                session_name = seat_get_string_property (seat, "quicklogin-session");
++
+             if (!session_name)
+                 session_name = user_get_xsession (user);
+             language = user_get_language (user);
+@@ -1283,6 +1289,12 @@ create_greeter_session (Seat *seat)
+     const gchar *autologin_username = seat_get_string_property (seat, "autologin-user");
+     if (g_strcmp0 (autologin_username, "") == 0)
+         autologin_username = NULL;
++
++    /* Configure for quick login */
++    const gchar *quicklogin_enabled = seat_get_string_property (seat, "quicklogin-enabled");
++    if (g_strcmp0 (quicklogin_enabled, "") == 0)
++        quicklogin_enabled = NULL;
++
+     const gchar *autologin_session = seat_get_string_property (seat, "autologin-session");
+     if (g_strcmp0 (autologin_session, "") == 0)
+         autologin_session = NULL;
+@@ -1294,6 +1306,8 @@ create_greeter_session (Seat *seat)
+         greeter_set_hint (greeter, "autologin-timeout", value);
+         if (autologin_username)
+             greeter_set_hint (greeter, "autologin-user", autologin_username);
++        if (quicklogin_enabled)
++            greeter_set_hint (greeter, "quicklogin-enabled", quicklogin_enabled);
+         if (autologin_session)
+             greeter_set_hint (greeter, "autologin-session", autologin_session);
+         if (autologin_guest)
+@@ -1650,6 +1664,86 @@ seat_get_is_stopping (Seat *seat)
+     return seat->priv->stopping;
+ }
+ 
++const gchar *
++get_deepin_greeter_last_username (void)
++{
++    GError *error = NULL;
++    gchar *name = NULL;
++
++    g_autoptr(GKeyFile) key_file = g_key_file_new();
++    if (!g_key_file_load_from_file(key_file, "/var/lib/lightdm/lightdm-deepin-greeter/state_user", G_KEY_FILE_NONE, &error)) 
++    {
++        g_debug("Failed to load key file: %s", error->message);
++        return NULL;
++    }
++
++    g_autofree gchar *value = g_key_file_get_value(key_file, "General", "last-user", &error);
++    if (error != NULL) 
++    {
++        g_debug("Failed to get value: %s", error->message);
++        return NULL;
++    }
++    // 删除"{"和"}"
++    if (value[0] == '{' && value[strlen(value) - 1] == '}')
++    {
++        value = g_strndup(value + 1, strlen(value) - 2);
++    }
++
++
++    gchar **tokens = g_strsplit(value, ",", -1);
++    for (gchar **token = tokens; *token; token++) 
++    {
++        gchar **pair = g_strsplit(*token, ":", -1);
++        gchar *key = g_strstrip(pair[0]);
++        gchar *val = g_strstrip(pair[1]);
++
++        // Find the "Name" key and extract its value
++        if (g_strcmp0(key, "\"Name\"") == 0) 
++        {
++            name = g_strstrip(g_strndup(val + 1, strlen(val) - 2));
++            break;
++        }
++
++        g_strfreev(pair);
++    }
++
++    g_strfreev(tokens);
++    return name;
++}
++
++gboolean 
++is_username_in_quicklogin_users (const gchar* username)
++{
++    GError *error = NULL;
++    gboolean result = FALSE;
++
++    g_autoptr(GKeyFile) key_file = g_key_file_new();
++    if (!g_key_file_load_from_file(key_file, "/var/lib/lightdm/lightdm-deepin-greeter/state_user", G_KEY_FILE_NONE, &error)) 
++    {
++        g_debug("Failed to load key file: %s", error->message);
++        return result;
++    }
++
++    g_autofree gchar *value = g_key_file_get_value(key_file, "General", "quicklogin-users", &error);
++    if (error != NULL) 
++    {
++        g_debug("Failed to get value: %s", error->message);
++        return NULL;
++    }
++
++    gchar **tokens = g_strsplit(value, ";", -1);
++    for (gchar** user = tokens; *user != NULL; user++) {
++        if (g_strcmp0(g_strstrip(*user), username) == 0 && *user != NULL) {
++            result = TRUE;
++            break;
++        }
++    }
++
++    g_strfreev(tokens);
++
++    return result;
++}
++
+ static void
+ seat_real_setup (Seat *seat)
+ {
+@@ -1662,6 +1756,10 @@ seat_real_start (Seat *seat)
+     const gchar *autologin_username = seat_get_string_property (seat, "autologin-user");
+     if (g_strcmp0 (autologin_username, "") == 0)
+         autologin_username = NULL;
++    /* Get quicklogin settings */
++    const gchar *quicklogin_enabled = seat_get_string_property (seat, "quicklogin-enabled");
++    if (g_strcmp0 (quicklogin_enabled, "") == 0)
++        quicklogin_enabled = NULL;
+     int autologin_timeout = seat_get_integer_property (seat, "autologin-user-timeout");
+     gboolean autologin_guest = seat_get_boolean_property (seat, "autologin-guest");
+     gboolean autologin_in_background = seat_get_boolean_property (seat, "autologin-in-background");
+@@ -1674,6 +1772,19 @@ seat_real_start (Seat *seat)
+             session = create_guest_session (seat, NULL);
+         else if (autologin_username != NULL)
+             session = create_user_session (seat, autologin_username, TRUE);
++        /* Quicklogin enabled */
++        else if (g_strcmp0 (quicklogin_enabled, "true") == 0 ) 
++        {
++            g_debug("start quicklogin");
++            const gchar *last_username = get_deepin_greeter_last_username ();
++            if (last_username != NULL && is_username_in_quicklogin_users(last_username))
++            {
++                g_debug("quicklogin last username: %s", last_username);
++                session = create_user_session (seat, last_username, TRUE);
++            }
++            if (session)
++                session_set_env(session, "DDE_QUICKLOGIN", "true");
++        }
+ 
+         if (session)
+             session_set_pam_service (session, seat_get_string_property (seat, "pam-autologin-service"));
+Index: lightdm/src/seat.h
+===================================================================
+--- lightdm.orig/src/seat.h
++++ lightdm/src/seat.h
+@@ -121,6 +121,10 @@ void seat_stop (Seat *seat);
+ 
+ gboolean seat_get_is_stopping (Seat *seat);
+ 
++const gchar *get_deepin_greeter_last_username (void);
++
++gboolean is_username_in_quicklogin_users(const gchar* username);
++
+ G_END_DECLS
+ 
+ #endif /* SEAT_H_ */
+Index: lightdm/data/pam/lightdm-autologin
+===================================================================
+--- lightdm.orig/data/pam/lightdm-autologin
++++ lightdm/data/pam/lightdm-autologin
+@@ -41,7 +41,7 @@ session [success=ok ignore=ignore module
+ 
+ # Unlock keyring when user no passwd login
+ -session  optional  pam_gnome_keyring.so auto_start
+-
++-session  optional  pam_deepin_keyring.so
+ password  required pam_deny.so
+ 
+ @include common-password


### PR DESCRIPTION
If quicklogin-enabled== true in the seat item in /etc/lightdm/lightdm.conf is true, it is a quick login situation, and the automatic login process will be used. First determine whether there is a record of the last login user and if it is in the automatic login user list, then automatically log in the last user. /var/lib/lightdm/lightdm-deepin-greeter/state_user. If there is no record or the configuration file does not exist, the original process will be used. And DDE_QUICKLOGIN == true is added to the environment variable.
If automatic login is enabled, the automatic login process will be used, ignoring the quick login configuration.

Log: as title
Pms: TASK-377223