### PR TITLE
fix: adjust OOMScore for lightdm service

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lightdm (1.30.0-0deepin6) unstable; urgency=medium
+
+  * fix: adjust OOMScore for lightdm service
+
+ -- fuleyi <fuleyi@uniontech.com>  Thu, 18 Dec 2025 11:07:35 +0800
+
 lightdm (1.30.0-0deepin5) unstable; urgency=medium
 
   * Restarting the service 5 seconds after lightdm exits on-failure

--- a/debian/lightdm.service
+++ b/debian/lightdm.service
@@ -17,6 +17,7 @@ Restart=on-failure
 RestartSec=5s
 IgnoreSIGPIPE=no
 BusName=org.freedesktop.DisplayManager
+OOMScoreAdjust=-999
 
 [Install]
 Alias=display-manager.service


### PR DESCRIPTION
Set OOMScoreAdjust to -999 to reduce the likelihood of lightdm being killed by the Out-Of-Memory killer. This improves system stability by ensuring the display manager remains available even under low memory conditions.

Influence:
1. Test system behavior under low memory conditions
2. Verify lightdm service stability during memory pressure
3. Check that other system processes are not adversely affected
4. Monitor system logs for OOM-related events

fix: 调整 lightdm 服务的 OOM 评分

将 OOMScoreAdjust 设置为 -999，降低 lightdm 被内存不足杀手终止的可能性。 这通过确保显示管理器在低内存条件下保持可用来提高系统稳定性。

Influence:
1. 测试低内存条件下的系统行为
2. 验证 lightdm 服务在内存压力下的稳定性
3. 检查其他系统进程是否受到不利影响
4. 监控系统日志中的 OOM 相关事件