### PR TITLE
fix: prevent segfault on init switch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lightdm (1.30.0-0deepin7) unstable; urgency=medium
+
+  * fix: SIGSEGV when switching between init 3 and init 5
+
+ -- fuleyi <fuleyi@uniontech.com>  Tue, 24 Jun 2026 10:00:00 +0800
+
 lightdm (1.30.0-0deepin6) unstable; urgency=medium
 
   * fix: adjust OOMScore for lightdm service

--- a/debian/patches/fix-sigsegv-on-init-switch.patch
+++ b/debian/patches/fix-sigsegv-on-init-switch.patch
@@ -1,0 +1,79 @@
+Index: lightdm/src/process.c
+===================================================================
+--- lightdm.orig/src/process.c
++++ lightdm/src/process.c
+@@ -133,7 +133,10 @@ process_set_env (Process *process, const
+     ProcessPrivate *priv = process_get_instance_private (process);
+     g_return_if_fail (process != NULL);
+     g_return_if_fail (name != NULL);
+-    g_hash_table_insert (priv->env, g_strdup (name), g_strdup (value));
++    if (value != NULL)
++        g_hash_table_insert (priv->env, g_strdup (name), g_strdup (value));
++    else
++        g_hash_table_remove (priv->env, name);
+ }
+ 
+ const gchar *
+@@ -244,10 +247,10 @@ process_start (Process *process, gboolea
+             environ = NULL;
+ #endif
+         for (guint i = 0; i < env_length; i++)
+-            setenv (env_keys[i], env_values[i], TRUE);
+-
+-        /* Reset SIGPIPE handler so the child has default behaviour (we disabled it at LightDM start) */
+-        signal (SIGPIPE, SIG_DFL);
++        {
++            if (env_values[i] != NULL)
++                setenv (env_keys[i], env_values[i], TRUE);
++        }
+ 
+         /* Reset SIGPIPE handler so the child has default behaviour (we disabled it at LightDM start) */
+         signal (SIGPIPE, SIG_DFL);
+Index: lightdm/src/seat-local.c
+===================================================================
+--- lightdm.orig/src/seat-local.c
++++ lightdm/src/seat-local.c
+@@ -288,7 +288,8 @@ seat_local_run_script (Seat *seat, Displ
+     {
+         const gchar *path = x_server_local_get_authority_file_path (X_SERVER_LOCAL (display_server));
+         process_set_env (script, "DISPLAY", x_server_get_address (X_SERVER (display_server)));
+-        process_set_env (script, "XAUTHORITY", path);
++        if (path)
++            process_set_env (script, "XAUTHORITY", path);
+     }
+ 
+     SEAT_CLASS (seat_local_parent_class)->run_script (seat, display_server, script);
+Index: lightdm/src/seat.c
+===================================================================
+--- lightdm.orig/src/seat.c
++++ lightdm/src/seat.c
+@@ -795,6 +795,15 @@ session_stopped_cb (Session *session, Se
+ 
+     DisplayServer *display_server = session_get_display_server (session);
+ 
++    /* If the seat is stopping, skip cleanup scripts - the display server
++     * may already be stopped and its resources freed (e.g. authority_file). */
++    if (priv->stopping)
++    {
++        check_stopped (seat);
++        g_object_unref (session);
++        return;
++    }
++
+     /* Cleanup */
+     if (!IS_GREETER_SESSION (session))
+     {
+@@ -808,13 +817,6 @@ session_stopped_cb (Session *session, Se
+     if (session == priv->session_to_activate)
+         g_clear_object (&priv->session_to_activate);
+ 
+-    if (priv->stopping)
+-    {
+-        check_stopped (seat);
+-        g_object_unref (session);
+-        return;
+-    }
+-
+     if (priv->wayland_mode_session_to_activate) {
+         l_debug(seat, "wayland mode, stop display server");
+         display_server_stop(display_server);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -21,3 +21,4 @@ uos-03-feat-can-switch-active-session.patch
 0002-feat-whitebox-scheme-adjustment.patch
 chore-adapt-to-qt6.patch
 uos-feat-dde-quick-login.patch
+fix-sigsegv-on-init-switch.patch


### PR DESCRIPTION
Address a segmentation fault in LightDM when switching init sessions. The crash was caused by NULL pointer dereferences in environment handling and session cleanup code. Key changes:
1. In process_set_env: properly handle NULL values by removing the key instead of inserting NULL
2. In process_start: skip setting environment variables with NULL values
3. In seat_local_run_script: add NULL check before setting XAUTHORITY
4. In session_stopped_cb: move seat stopping check earlier to avoid accessing freed display server resources

This fixes crash scenarios where the display server may already be stopped and its resources freed during session transitions.

Influence:
1. Test session switching between different init types to verify no crashes occur
2. Verify environment variables are correctly handled when values become NULL
3. Test session cleanup when seat is already in stopping state
4. Ensure proper handling of XAUTHORITY path when display server is unavailable
5. Test with various session termination scenarios to validate crash prevention

fix: 防止初始化切换时发生段错误

解决LightDM在切换初始化会话时发生的段错误问题。崩溃是由于环境处理和会话
清理代码中的空指针解引用引起的。主要更改：
1. 在process_set_env中：通过删除键而不是插入NULL值来正确处理NULL值
2. 在process_start中：跳过设置值为NULL的环境变量
3. 在seat_local_run_script中：设置XAUTHORITY前添加NULL检查
4. 在session_stopped_cb中：将座位停止检查提前以避免访问已释放的显示服务 器资源

这修复了在会话转换期间显示服务器可能已停止且其资源已释放的崩溃场景。

Influence:
1. 测试在不同初始化类型之间切换会话，验证不会发生崩溃
2. 验证环境变量在值变为NULL时是否正确处理
3. 测试在座位已处于停止状态时的会话清理
4. 确保在显示服务器不可用时正确处理XAUTHORITY路径
5. 测试各种会话终止场景以验证崩溃预防效果

PMS: BUG-363347